### PR TITLE
rebrand: KoalaOps → Skyhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A GitHub Action that ensures an Amazon ECR repository exists, creating it if nec
 
 ```yaml
 - name: Ensure ECR Repository Exists
-  uses: KoalaOps/ensure-ecr-repository@v1
+  uses: skyhook-io/ensure-ecr-repository@v1
   with:
     repository-name: my-app
     aws-region: us-east-1
@@ -47,7 +47,7 @@ jobs:
 
       - name: Ensure ECR Repository Exists
         id: ecr-repo
-        uses: KoalaOps/ensure-ecr-repository@v1
+        uses: skyhook-io/ensure-ecr-repository@v1
         with:
           repository-name: my-app
           aws-region: us-east-1
@@ -66,7 +66,7 @@ jobs:
 ```yaml
 - name: Ensure ECR Repository Exists
   id: ensure-repo
-  uses: KoalaOps/ensure-ecr-repository@v1
+  uses: skyhook-io/ensure-ecr-repository@v1
   with:
     repository-name: my-service
     aws-region: us-west-2
@@ -176,8 +176,8 @@ Error: Repository does not exist for repository with name 'my-app'
 ## Contributing
 
 We welcome contributions! Feel free to:
-- 🐛 **Report bugs** by [creating an issue](https://github.com/KoalaOps/ensure-ecr-repository/issues)
-- 💡 **Suggest features** by [creating an issue](https://github.com/KoalaOps/ensure-ecr-repository/issues)  
+- 🐛 **Report bugs** by [creating an issue](https://github.com/skyhook-io/ensure-ecr-repository/issues)
+- 💡 **Suggest features** by [creating an issue](https://github.com/skyhook-io/ensure-ecr-repository/issues)  
 - 🛠️ **Submit pull requests** with improvements or fixes
 
 No special process required - just fork, make your changes, and submit a PR!
@@ -188,8 +188,8 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## Support
 
-- 🐛 **Bug reports**: [Create an issue](https://github.com/KoalaOps/ensure-ecr-repository/issues)
-- 💡 **Feature requests**: [Create an issue](https://github.com/KoalaOps/ensure-ecr-repository/issues)
+- 🐛 **Bug reports**: [Create an issue](https://github.com/skyhook-io/ensure-ecr-repository/issues)
+- 💡 **Feature requests**: [Create an issue](https://github.com/skyhook-io/ensure-ecr-repository/issues)
 
 ---
 

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: "Ensure ECR Repository Exists"
 description: "Ensures an Amazon ECR repository exists, creating it if necessary. Requires AWS credentials to be configured."
-author: "KoalaOps"
+author: "Skyhook"
 
 branding:
   icon: "package"


### PR DESCRIPTION
## Summary
Update all references from KoalaOps to Skyhook as part of the rebranding initiative.

## Changes
- Organization: `KoalaOps` → `skyhook-io`
- Author: `KoalaOps` → `Skyhook`
- Product name: `Koala` → `Skyhook` (where applicable)
- All usage examples updated to reference `skyhook-io/*`
- All documentation and URLs updated

## Notes
- This PR should be merged before transferring the repository to the skyhook-io organization
- After transfer, GitHub will automatically redirect old URLs to new ones